### PR TITLE
binaryfusefilter: use wrapping add instead of `@addWithOverflow`

### DIFF
--- a/src/binaryfusefilter.zig
+++ b/src/binaryfusefilter.zig
@@ -170,8 +170,7 @@ pub fn BinaryFuse(comptime T: type) type {
                 var got_num_keys: usize = 0;
                 while (keys.next()) |key| {
                     if (is_debug) got_num_keys += 1;
-                    var sum: u64 = undefined;
-                    _ = @addWithOverflow(u64, key, self.seed, &sum);
+                    const sum: u64 = key +% self.seed;
                     const hash: u64 = util.murmur64(sum);
 
                     const shift_count = @as(usize, 64) - @as(usize, block_bits);


### PR DESCRIPTION
`@addWithOverflow` only takes 2 arguments now; however since the overflow bit is ignored we can just use a wrapping add.



- [x] By selecting this checkbox, I agree to license my contributions to this project under the license(s) described in the LICENSE file, and I have the right to do so or have received permission to do so by an employer or client I am producing work for whom has this right.